### PR TITLE
Support dSYM debugging properly

### DIFF
--- a/src/Tulsi.xcodeproj/project.pbxproj
+++ b/src/Tulsi.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		090B85D51EDF8D5400034C76 /* patchDsym.sh in Resources */ = {isa = PBXBuildFile; fileRef = 090B85D41EDF8D5400034C76 /* patchDsym.sh */; };
 		2D9DB34A1E5DECA40021EAF4 /* XCTRunner.entitlements in Resources */ = {isa = PBXBuildFile; fileRef = 2D9DB3491E5DEC680021EAF4 /* XCTRunner.entitlements */; };
 		3D029B581C6421B400779E8E /* TaskRunner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D029B571C6421B400779E8E /* TaskRunner.swift */; };
 		3D029C7E1C650DD100779E8E /* ProjectEditorPackageManagerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D029C7C1C650DD100779E8E /* ProjectEditorPackageManagerViewController.swift */; };
@@ -194,6 +195,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		090B85D41EDF8D5400034C76 /* patchDsym.sh */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.script.sh; path = patchDsym.sh; sourceTree = "<group>"; };
 		2D9DB3491E5DEC680021EAF4 /* XCTRunner.entitlements */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.entitlements; path = XCTRunner.entitlements; sourceTree = "<group>"; };
 		3D029B571C6421B400779E8E /* TaskRunner.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TaskRunner.swift; sourceTree = "<group>"; };
 		3D029C7C1C650DD100779E8E /* ProjectEditorPackageManagerViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProjectEditorPackageManagerViewController.swift; sourceTree = "<group>"; };
@@ -478,6 +480,7 @@
 		3DAC27671C3AD2510040F42C /* Scripts */ = {
 			isa = PBXGroup;
 			children = (
+				090B85D41EDF8D5400034C76 /* patchDsym.sh */,
 				3D329D0D1C4831EF00DFBD0F /* bazel_build.py */,
 				D33C204E1EC108CC00867450 /* tulsi_logging.py */,
 				3D156AE11C1C8D9C00183439 /* bazel_clean.sh */,
@@ -794,6 +797,7 @@
 				D33C204F1EC108CC00867450 /* tulsi_logging.py in Resources */,
 				3D9926911C29F1410094E098 /* bazel_clean.sh in Resources */,
 				3DFB7C4B1C81F78000376760 /* command_line_splitter.sh in Resources */,
+				090B85D51EDF8D5400034C76 /* patchDsym.sh in Resources */,
 				3DBEFACD1C2A1F7200119556 /* Localizable.strings in Resources */,
 				3D9485411C3193F00026CE41 /* Options.strings in Resources */,
 				3D5A1B581D1B3485006FC2A6 /* StubInfoPlist.plist in Resources */,

--- a/src/TulsiGenerator/Scripts/patchDsym.sh
+++ b/src/TulsiGenerator/Scripts/patchDsym.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+set -euo pipefail
+
+if [[ $# -ne 4 ]]; then
+  echo "Usage: $0 <dwarfpatcher> <dsym> <real-workspace> <bazel-workspace>"
+  exit 1
+fi
+
+DWARFPATCHER="$1"
+DSYM="$2"
+REAL_WORKSPACE="$3"
+# for some reason, we need the tulsi project to begin without the leading /private, not sure why
+# The bash magic here just strips that /private prefix
+BAZEL_WORKSPACE="/${4#/*/}"
+
+PREFIX_MAP=$(mktemp)
+# for ($TO_REPLACE, $RELATIVE_PATH) in dwarf symbols
+for p in $(xcrun dwarfdump "$DSYM" -r 0 | grep AT_comp_dir -B2 | grep -v '\-\-' | awk 'NR%3{printf "%s ",$0;next;}1' | grep 'bazel' | perl -pe 's/.*?AT_name.."+(.*?)".*?"(.*?)"\s.*/\2,\1/g' | sort | uniq); do
+    IFS=","; set -- $p
+    TO_REPLACE="$1"
+    RELATIVE_PATH="$2"
+
+    # Dwarfpatch expects a file with sed-style ,needle,new-needle, replacements per line
+    # Here we use the bazel sandbox path and replace it with the path to our iOS workspace
+    #
+    # Dwarfpatch uses this file to fix our dSYM
+    if [[ "$RELATIVE_PATH" == external* ]]; then
+      echo ",$TO_REPLACE,$BAZEL_WORKSPACE," >> "$PREFIX_MAP"
+    else
+      echo ",$TO_REPLACE,$REAL_WORKSPACE," >> "$PREFIX_MAP"
+    fi
+done
+"$DWARFPATCHER" -d -m "$PREFIX_MAP" "$DSYM"
+rm "$PREFIX_MAP"

--- a/src/TulsiGenerator/TulsiXcodeProjectGenerator.swift
+++ b/src/TulsiGenerator/TulsiXcodeProjectGenerator.swift
@@ -53,6 +53,7 @@ public final class TulsiXcodeProjectGenerator {
         postProcessor: bundle.url(forResource: "post_processor",
                                              withExtension: "",
                                              subdirectory: "Utilities")!,
+        patchDsym: bundle.url(forResource: "patchDsym", withExtension: "sh")!,
         uiRunnerEntitlements: bundle.url(forResource: "XCTRunner", withExtension: "entitlements")!,
         stubInfoPlist: bundle.url(forResource: "StubInfoPlist", withExtension: "plist")!,
         stubIOSAppExInfoPlistTemplate: bundle.url(forResource: "StubIOSAppExtensionInfoPlist", withExtension: "plist")!,

--- a/src/TulsiGenerator/XcodeProjectGenerator.swift
+++ b/src/TulsiGenerator/XcodeProjectGenerator.swift
@@ -32,6 +32,7 @@ final class XcodeProjectGenerator {
     let cleanScript: URL  // The script to run on "clean" actions.
     let extraBuildScripts: [URL] // Any additional scripts to install into the project bundle.
     let postProcessor: URL  // Binary post processor utility.
+    let patchDsym: URL // The script to properly patch a dysm.
     let uiRunnerEntitlements: URL  // Entitlements file template for UI Test runner apps.
     let stubInfoPlist: URL  // Stub Info.plist (needed for Xcode 8).
     let stubIOSAppExInfoPlistTemplate: URL  // Stub Info.plist (needed for app extension targets).
@@ -65,6 +66,7 @@ final class XcodeProjectGenerator {
   private static let CleanScript = "bazel_clean.sh"
   private static let WorkspaceFile = "WORKSPACE"
   private static let PostProcessorUtil = "post_processor"
+  private static let PatchDsym = "patchDsym.sh"
   private static let UIRunnerEntitlements = "XCTRunner.entitlements"
   private static let StubInfoPlistFilename = "StubInfoPlist.plist"
   private static let StubWatchOS2InfoPlistFilename = "StubWatchOS2InfoPlist.plist"
@@ -736,6 +738,7 @@ final class XcodeProjectGenerator {
       localizedMessageLogger.infoMessage("Installing scripts")
       installFiles([(resourceURLs.buildScript, XcodeProjectGenerator.BuildScript),
                     (resourceURLs.cleanScript, XcodeProjectGenerator.CleanScript),
+                    (resourceURLs.patchDsym, XcodeProjectGenerator.PatchDsym)
                    ],
                    toDirectory: scriptDirectoryURL)
       installFiles(resourceURLs.extraBuildScripts.map { ($0, $0.lastPathComponent) },

--- a/src/tools/post_processor/post_processor/covmap_patcher.cc
+++ b/src/tools/post_processor/post_processor/covmap_patcher.cc
@@ -70,8 +70,7 @@ std::unique_ptr<uint8_t[]> CovmapPatcher::PatchCovmapSection(
     size_t *new_data_length,
     bool *data_was_modified) const {
   assert(section && new_data_length && data_was_modified);
-  return section->PatchFilenamesAndInvalidate(old_prefix_,
-                                              new_prefix_,
+  return section->PatchFilenamesAndInvalidate(prefix_map_,
                                               new_data_length,
                                               data_was_modified);
 }

--- a/src/tools/post_processor/post_processor/covmap_patcher.h
+++ b/src/tools/post_processor/post_processor/covmap_patcher.h
@@ -16,6 +16,7 @@
 #define POST_PROCESSOR_COVMAPPATCHER_H_
 
 #include <string>
+#include <unordered_map>
 
 #include "patcher_base.h"
 
@@ -27,10 +28,9 @@ class CovmapSection;
 /// Provides utilities to patch LLVM coverage map data.
 class CovmapPatcher : public PatcherBase {
  public:
-  CovmapPatcher(const std::string &old_prefix,
-                const std::string &new_prefix,
+  CovmapPatcher(const std::unordered_map<std::string, std::string> &prefix_map,
                 bool verbose = false) :
-      PatcherBase(old_prefix, new_prefix, verbose) {
+      PatcherBase(prefix_map, verbose) {
   }
 
   virtual ReturnCode Patch(MachOFile *f);

--- a/src/tools/post_processor/post_processor/covmap_section.cc
+++ b/src/tools/post_processor/post_processor/covmap_section.cc
@@ -87,11 +87,15 @@ ReturnCode CovmapSection::Parse() {
 }
 
 std::unique_ptr<uint8_t[]> CovmapSection::PatchFilenamesAndInvalidate(
-    const std::string &old_prefix,
-    const std::string &new_prefix,
+    const std::unordered_map<std::string,std::string> &prefix_map,
     size_t *section_length,
     bool *data_was_modified) {
   assert(section_length && data_was_modified);
+
+  // TODO(bkase): Actually use the full prefix map
+  auto iter = prefix_map.begin();
+  std::string old_prefix = iter->first;
+  std::string new_prefix = iter->second;
 
   size_t prefix_size = old_prefix.size();
   auto old_prefix_begin = old_prefix.cbegin();

--- a/src/tools/post_processor/post_processor/covmap_section.h
+++ b/src/tools/post_processor/post_processor/covmap_section.h
@@ -19,6 +19,7 @@
 
 #include <string>
 #include <vector>
+#include <unordered_map>
 
 #include "dwarf_buffer_reader.h"
 #include "return_code.h"
@@ -47,8 +48,7 @@ class CovmapSection {
   ///          CovmapSection's data member. It is unsafe to invoke any method on
   ///          this instance after this method returns.
   std::unique_ptr<uint8_t[]> PatchFilenamesAndInvalidate(
-      const std::string &old_prefix,
-      const std::string &new_prefix,
+      const std::unordered_map<std::string,std::string> &prefix_map,
       size_t *section_length,
       bool *data_was_modified);
 

--- a/src/tools/post_processor/post_processor/dwarf_buffer_reader.h
+++ b/src/tools/post_processor/post_processor/dwarf_buffer_reader.h
@@ -15,7 +15,7 @@
 #ifndef POST_PROCESSOR_DWARFBUFFERREADER_H_
 #define POST_PROCESSOR_DWARFBUFFERREADER_H_
 
-#include <cassert>
+#include <assert.h>
 #include <string>
 
 namespace post_processor {

--- a/src/tools/post_processor/post_processor/dwarf_string_patcher.h
+++ b/src/tools/post_processor/post_processor/dwarf_string_patcher.h
@@ -21,6 +21,7 @@
 #include <map>
 #include <string>
 #include <vector>
+#include <unordered_map>
 
 #include "patcher_base.h"
 
@@ -33,10 +34,9 @@ class MachOFile;
 /// Provides utilities to patch DWARF string table entries.
 class DWARFStringPatcher : public PatcherBase {
  public:
-  DWARFStringPatcher(const std::string &old_prefix,
-                     const std::string &new_prefix,
+  DWARFStringPatcher(const std::unordered_map<std::string, std::string> &prefix_map,
                      bool verbose = false) :
-      PatcherBase(old_prefix, new_prefix, verbose) {
+      PatcherBase(prefix_map, verbose) {
   }
 
   virtual ReturnCode Patch(MachOFile *f);

--- a/src/tools/post_processor/post_processor/mach_o_container.cc
+++ b/src/tools/post_processor/post_processor/mach_o_container.cc
@@ -30,9 +30,9 @@ MachOContainer::MachOContainer(const std::string &filename, bool verbose) :
     filename_(filename),
     file_(nullptr),
     verbose_(verbose),
+    host_byte_order_(NXHostByteOrder()),
     content_32_(nullptr),
-    content_64_(nullptr),
-    host_byte_order_(NXHostByteOrder()) {
+    content_64_(nullptr) {
 }
 
 MachOContainer::~MachOContainer() {

--- a/src/tools/post_processor/post_processor/patcher_base.h
+++ b/src/tools/post_processor/post_processor/patcher_base.h
@@ -16,6 +16,7 @@
 #define POST_PROCESSOR_PATCHERBASE_H_
 
 #include <string>
+#include <unordered_map>
 
 #include "return_code.h"
 
@@ -27,11 +28,9 @@ class MachOFile;
 /// Virtual base class for patchers.
 class PatcherBase {
  public:
-  PatcherBase(const std::string &old_prefix,
-              const std::string &new_prefix,
+  PatcherBase(const std::unordered_map<std::string, std::string> &prefix_map,
               bool verbose = false) :
-      old_prefix_(old_prefix),
-      new_prefix_(new_prefix),
+      prefix_map_(prefix_map),
       verbose_(verbose) {
   }
 
@@ -52,8 +51,7 @@ class PatcherBase {
   }
 
  protected:
-  const std::string old_prefix_;
-  const std::string new_prefix_;
+  const std::unordered_map<std::string,std::string> prefix_map_;
   bool verbose_;
 };
 


### PR DESCRIPTION
Debugging inside a tulsi generated project currently does not work (see
https://github.com/bazelbuild/tulsi/issues/16 ).

The lldbinit path has always been flaky for me, but it seems like the
dSYM one works well.

The post_processor was not correctly patching the correct paths in the
latest version of tulsi. I imagine that this is due to a change in the
way Bazel builds occur such that there are much more ephemeral paths
that need to be patched.

I attempted to just invoke the post_processor per path, but in large
projects, patching the dSYM was taking close to a minute. This is
unacceptable since the patching needs to run every build.

To fix this, I changed the post_processor to consume a map of path
replacements and then rather than traverse the dSYM per replacement, we
just traverse the dSYM once and check the map at every step. dSYM
replacement now is under 50ms (in fact it takes longer to find the
paths we need to replace).

The logic to find the paths, is located inside a new script
`patchDsym.sh`. This is a separate script because it needs to invoke
`xcrun dwarfdump` and pass the output through many pipes to extract the
proper input for the post_processor map.

```
  Usage: ./patchDsym.sh <dwarfpatcher> \
                        <dsym> \
                        <real-workspace> \
                        <bazel-workspace>
```

The patchDsym.sh takes a path to the dwarfpatcher (the post_processor
binary in this case), the dsym to patch, the path to the project
workspace where a developer does her programming, and the path to the to
root of the bazel workspace.

All other changes support the addition of this script and the new
behavior of the post_processor.

See this branch of a simple bazel project to see debugging working
properly (for normal and external deps):
https://github.com/bkase/debugging-tulsi-broken/tree/working-patcher