### PR TITLE
Make genfiles path recursive

### DIFF
--- a/src/TulsiGenerator/PBXTargetGenerator.swift
+++ b/src/TulsiGenerator/PBXTargetGenerator.swift
@@ -762,7 +762,7 @@ final class PBXTargetGenerator: PBXTargetGeneratorProtocol {
 
     let searchPaths = ["$(\(PBXTargetGenerator.BazelWorkspaceSymlinkVarName))",
                        "$(\(PBXTargetGenerator.WorkspaceRootVarName))/\(bazelBinPath)",
-                       "$(\(PBXTargetGenerator.WorkspaceRootVarName))/\(bazelGenfilesPath)",
+                       "$(\(PBXTargetGenerator.WorkspaceRootVarName))/\(bazelGenfilesPath)/**",
                        "$(\(PBXTargetGenerator.BazelWorkspaceSymlinkVarName))/\(tulsiIncludesPath)"
     ]
     // Ideally this would use USER_HEADER_SEARCH_PATHS but some code generation tools (e.g.,


### PR DESCRIPTION
Generated code that needs to be indexed should be available but will likely not be located at the root genfiles directory. This should be recursive by default.