### PR TITLE
[bug fix] Use case insensitive workspace and output folder path compa…

### DIFF
--- a/src/TulsiGenerator/PBXTargetGenerator.swift
+++ b/src/TulsiGenerator/PBXTargetGenerator.swift
@@ -371,9 +371,9 @@ final class PBXTargetGenerator: PBXTargetGeneratorProtocol {
 
     let slashTerminatedOutputFolder = outputFolder + (outputFolder.hasSuffix("/") ? "" : "/")
     let slashTerminatedWorkspaceRoot = workspaceRoot + (workspaceRoot.hasSuffix("/") ? "" : "/")
-
+    
     // If workspaceRoot == outputFolder, return a relative group with no path.
-    if slashTerminatedOutputFolder == slashTerminatedWorkspaceRoot {
+    if slashTerminatedOutputFolder.caseInsensitiveCompare(slashTerminatedWorkspaceRoot) == .orderedSame  {
       return PBXGroup(name: "mainGroup", path: nil, sourceTree: .SourceRoot, parent: nil)
     }
 

--- a/src/TulsiGenerator/PBXTargetGenerator.swift
+++ b/src/TulsiGenerator/PBXTargetGenerator.swift
@@ -379,7 +379,8 @@ final class PBXTargetGenerator: PBXTargetGeneratorProtocol {
 
     // If outputFolder contains workspaceRoot, return a relative group with the path from
     // outputFolder to workspaceRoot
-    if workspaceRoot.hasPrefix(slashTerminatedOutputFolder) {
+
+    if workspaceRoot.lowercased().hasPrefix(slashTerminatedOutputFolder.lowercased()) {
       let index = workspaceRoot.characters.index(workspaceRoot.startIndex, offsetBy: slashTerminatedOutputFolder.characters.count)
       let relativePath = workspaceRoot.substring(from: index)
       return PBXGroup(name: "mainGroup",
@@ -390,7 +391,7 @@ final class PBXTargetGenerator: PBXTargetGeneratorProtocol {
 
     // If workspaceRoot contains outputFolder, return a relative group using .. to walk up to
     // workspaceRoot from outputFolder.
-    if outputFolder.hasPrefix(slashTerminatedWorkspaceRoot) {
+    if outputFolder.lowercased().hasPrefix(slashTerminatedWorkspaceRoot.lowercased()) {
       let index = outputFolder.characters.index(outputFolder.startIndex, offsetBy: slashTerminatedWorkspaceRoot.characters.count + 1)
       let pathToWalkBackUp = outputFolder.substring(from: index) as NSString
       let numberOfDirectoriesToWalk = pathToWalkBackUp.pathComponents.count


### PR DESCRIPTION
…risons when

creating "mainGroup". If you navigate to your workspace from the command
line, ignoring the capitalization of folders, Tulsi can generate
absolute paths which breaks project portability.